### PR TITLE
Add --insecure option to check_http

### DIFF
--- a/cmd/check_http/README.md
+++ b/cmd/check_http/README.md
@@ -7,6 +7,7 @@ Performs an HTTP GET request and returns a result based on the HTTP response cod
 
 ## Options
 - `--url` (`-u`): The URL to check. Required.
+- `--insecure` (`-k`): Do not validate the server's certificate
 - `--redirect` (`-r`): If set, follow redirects. Default is do not follow redirects.
 - `--timeout` (`-t`): Timeout in seconds to wait for HTTP server response. Default is 15 seconds.
 - `--path` (`-p`) and `--expression`: Used together. A json path and expression value to compare. Use this rather than `--path` and `--expectedValue` for making comparisons.

--- a/cmd/check_http/cmd/root.go
+++ b/cmd/check_http/cmd/root.go
@@ -9,8 +9,8 @@ import (
 )
 
 // Execute runs the root command
-func Execute(apiCheckHTTP func(string, bool, int, string, string, string, string) (string, int)) int {
-	var redirect bool
+func Execute(apiCheckHTTP func(string, bool, bool, int, string, string, string, string) (string, int)) int {
+	var redirect, insecure bool
 	var exitCode, timeout int
 	var url, format, path, expectedValue, expression string
 
@@ -20,7 +20,7 @@ func Execute(apiCheckHTTP func(string, bool, int, string, string, string, string
 		Long:  `Perform an HTTP get request and assert whether it is OK, warning or critical.`,
 		Run: func(cmd *cobra.Command, args []string) {
 			cmd.ParseFlags(os.Args)
-			msg, retval := apiCheckHTTP(url, redirect, timeout, format, path, expectedValue, expression)
+			msg, retval := apiCheckHTTP(url, redirect, insecure, timeout, format, path, expectedValue, expression)
 
 			fmt.Println(msg)
 			exitCode = retval
@@ -31,6 +31,7 @@ func Execute(apiCheckHTTP func(string, bool, int, string, string, string, string
 
 	rootCmd.Flags().StringVarP(&url, "url", "u", "http://127.0.0.1", "the URL to check")
 	rootCmd.Flags().BoolVarP(&redirect, "redirect", "r", false, "follow redirects?")
+	rootCmd.Flags().BoolVarP(&insecure, "insecure", "k", false, "do not validate certificate")
 	rootCmd.Flags().IntVarP(&timeout, "timeout", "t", 15, "timeout in seconds")
 	rootCmd.Flags().StringVarP(&format, "format", "f", "", "The expected response format: json")
 	rootCmd.Flags().StringVarP(&path, "path", "p", "", "The path in the return value data to test against the expected value")

--- a/lib/app/nagiosfoundation/check_http_test.go
+++ b/lib/app/nagiosfoundation/check_http_test.go
@@ -24,63 +24,63 @@ func TestCheckHTTP(t *testing.T) {
 
 	// Code 200
 	httpStatus = http.StatusOK
-	_, code := CheckHTTP(httpServer.URL, false, 1, format, path, expectedValue, "")
+	_, code := CheckHTTP(httpServer.URL, false, false, 1, format, path, expectedValue, "")
 	if code != 0 {
 		t.Error("CheckHTTP() should return code of 0 when on OK (200) response")
 	}
 
 	// Code 400
 	httpStatus = http.StatusBadRequest
-	_, code = CheckHTTP(httpServer.URL, false, 1, format, path, expectedValue, "")
+	_, code = CheckHTTP(httpServer.URL, false, false, 1, format, path, expectedValue, "")
 	if code != 2 {
 		t.Error("CheckHTTP() should return code of 2 when on bad request (400) response")
 	}
 
 	// Code 300
 	httpStatus = http.StatusMultipleChoices
-	_, code = CheckHTTP(httpServer.URL, false, 1, format, path, expectedValue, "")
+	_, code = CheckHTTP(httpServer.URL, false, false, 1, format, path, expectedValue, "")
 	if code != 1 {
 		t.Error("CheckHTTP() should return code of 2 when on multiple choices (300) response")
 	}
 
 	// Code 300 with redirect on
 	httpStatus = http.StatusMultipleChoices
-	_, code = CheckHTTP(httpServer.URL, true, 1, format, path, expectedValue, "")
+	_, code = CheckHTTP(httpServer.URL, true, false, 1, format, path, expectedValue, "")
 	if code != 0 {
 		t.Error("CheckHTTP() should return code of 0 when on multiple choices (300) with redirect response")
 	}
 
 	// Code 200 with format json and a match on expected value
 	httpStatus = http.StatusOK
-	_, code = CheckHTTP(httpServer.URL, false, 1, "json", "id", idValueString, "")
+	_, code = CheckHTTP(httpServer.URL, false, false, 1, "json", "id", idValueString, "")
 	if code != 0 {
 		t.Error("CheckHTTP() should return code of 0 when json path matches expected value")
 	}
 
 	// Code 200 with format json and failed match on expected value
 	httpStatus = http.StatusOK
-	_, code = CheckHTTP(httpServer.URL, false, 1, "json", "id", "failmatch", "")
+	_, code = CheckHTTP(httpServer.URL, false, false, 1, "json", "id", "failmatch", "")
 	if code != 2 {
 		t.Error("CheckHTTP() should return code of 2 when json path does not match expected value")
 	}
 
 	// Code 200 with format json and expression true
 	httpStatus = http.StatusOK
-	_, code = CheckHTTP(httpServer.URL, false, 1, "json", "id", "", "!= \""+idValueString+"\"")
+	_, code = CheckHTTP(httpServer.URL, false, false, 1, "json", "id", "", "!= \""+idValueString+"\"")
 	if code != 2 {
 		t.Error("CheckHTTP() should return code of 2 when json path causes expression to return false")
 	}
 
 	// Code 200 with format json and no expected value or expression
 	httpStatus = http.StatusOK
-	_, code = CheckHTTP(httpServer.URL, false, 1, "json", "id", "", "")
+	_, code = CheckHTTP(httpServer.URL, false, false, 1, "json", "id", "", "")
 	if code != 2 {
 		t.Error("CheckHTTP() should return code of 2 with json path but no expected value or expression")
 	}
 
 	// Code 200 with format json and but both expected value and expression given
 	httpStatus = http.StatusOK
-	_, code = CheckHTTP(httpServer.URL, false, 1, "json", "id", "expectedvalue", "expression")
+	_, code = CheckHTTP(httpServer.URL, false, false, 1, "json", "id", "expectedvalue", "expression")
 	if code != 2 {
 		t.Error("CheckHTTP() should return code of 2 with json path but no expected value or expression")
 	}
@@ -88,7 +88,7 @@ func TestCheckHTTP(t *testing.T) {
 	// Code 200 with format json and expression true using integer
 	responseBody = `{"id":` + idValueString + `}`
 	httpStatus = http.StatusOK
-	_, code = CheckHTTP(httpServer.URL, false, 1, "json", "id", "", "== "+idValueString)
+	_, code = CheckHTTP(httpServer.URL, false, false, 1, "json", "id", "", "== "+idValueString)
 	if code != 0 {
 		t.Errorf("CheckHTTP() should return code of 0 with json path but and comparison to int %d", idValue)
 	}
@@ -96,7 +96,7 @@ func TestCheckHTTP(t *testing.T) {
 	// Invalid format
 	responseBody = `{"id":` + idValueString + `}`
 	httpStatus = http.StatusOK
-	_, code = CheckHTTP(httpServer.URL, false, 1, "invalidformat", "id", "", "== "+idValueString)
+	_, code = CheckHTTP(httpServer.URL, false, false, 1, "invalidformat", "id", "", "== "+idValueString)
 	if code != 2 {
 		t.Errorf("CheckHTTP() should return code of 2 when given an invalid format")
 	}
@@ -104,7 +104,7 @@ func TestCheckHTTP(t *testing.T) {
 	// Invalid path
 	responseBody = `{"id":` + idValueString + `}`
 	httpStatus = http.StatusOK
-	_, code = CheckHTTP(httpServer.URL, false, 1, "json", "invalidpath", "", "== "+idValueString)
+	_, code = CheckHTTP(httpServer.URL, false, false, 1, "json", "invalidpath", "", "== "+idValueString)
 	if code != 2 {
 		t.Errorf("CheckHTTP() should return code of 2 when given an invalid path")
 	}
@@ -114,16 +114,36 @@ func TestCheckHTTP(t *testing.T) {
 
 	// No server for connection
 	httpStatus = http.StatusOK
-	_, code = CheckHTTP(httpServer.URL, false, 1, format, path, expectedValue, "")
+	_, code = CheckHTTP(httpServer.URL, false, false, 1, format, path, expectedValue, "")
 	if code != 2 {
 		t.Error("CheckHTTP() should return code of 2 when no server is available")
 	}
 
 	// Invalid URL
 	httpStatus = http.StatusOK
-	_, code = CheckHTTP("invalid%url", false, 1, format, path, expectedValue, "")
+	_, code = CheckHTTP("invalid%url", false, false, 1, format, path, expectedValue, "")
 	if code != 2 {
 		t.Error("CheckHTTP() should return code of 2 when given an unparseable URL")
+	}
+}
+
+func TestCheckHTTPS(t *testing.T) {
+	httpsServer := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte(""))
+	}))
+	defer httpsServer.Close()
+
+	// Code 200 w/ insecure true
+	_, code := CheckHTTP(httpsServer.URL, false, true, 1, "", "", "", "")
+	if code != statusCodeOK {
+		t.Error("CheckHTTP() should return code of 0 when on OK (200) response")
+	}
+
+	// Code 200 w/ insecure false
+	_, code = CheckHTTP(httpsServer.URL, false, false, 1, "", "", "", "")
+	if code == statusCodeCritical {
+		t.Error("CheckHTTP() should return code of 2 on invalid certificate")
 	}
 }
 


### PR DESCRIPTION
Do not validate certificate when the `--insecure` option is given (like with `curl`'s `--insecure` option).
Resolves #181 